### PR TITLE
Add Tracking protection icon api and test

### DIFF
--- a/foxpuppet/windows/base.py
+++ b/foxpuppet/windows/base.py
@@ -53,5 +53,4 @@ class BaseWindow(object):
 
     def switch_to(self):
         """Switches focus for Selenium commands to this window."""
-
         self.selenium.switch_to.window(self.handle)

--- a/foxpuppet/windows/browser/navbar.py
+++ b/foxpuppet/windows/browser/navbar.py
@@ -2,33 +2,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.wait import WebDriverWait
-import time
+
+from foxpuppet.region import Region
 
 
-class NavBar(object):
+class NavBar(Region):
 
-    """Representation of the NavBar
-    :param selenium: WebDriver Object
-    :type selenium:
-        :py:class:`~selenium.webdriver.remote.webdriver.WebDriver` object
+    """Representation of the Navigation Bar
+    :param window: Window object this region appears in.
+    :param root: element that serves as the root for the region.
+    :type window: :py:class:`~.windows.BaseWindow`
+    :type root: :py:class:`~selenium.webdriver.remote.webelement.WebElement`
     """
-
-    _tracking_protection_shield_locator = (By.CSS_SELECTOR, '#tracking-protection-icon:-moz-lwtheme')
-
-    def __init__(self, selenium, *args, **kwargs):
-        self.selenium = selenium
+    _tracking_protection_shield_locator = (By.ID, 'tracking-protection-icon')
 
     @property
-    def tracking_shield(self):
-        """Returns the Tacking Protection enabled shield"""
-        time.sleep(30)
+    def is_tracking_shield_displayed(self):
+        """Tracking Protection shield
+        :returns: True or False if the Tracking Shield is displayed
+        :type return: boolean
+        """
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
-            return self.selenium.find_element(
+            el = self.selenium.find_element(
                 *self._tracking_protection_shield_locator)
-            #WebDriverWait(self.selenium, timeout=10).until(
-            #    lambda _: self.selenium.find_element(
-            #        *self._tracking_protection_shield_locator)
-            #)
+            return bool(el.get_attribute('state'))

--- a/foxpuppet/windows/browser/navbar.py
+++ b/foxpuppet/windows/browser/navbar.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+import time
+
+
+class NavBar(object):
+
+    """Representation of the NavBar
+    :param selenium: WebDriver Object
+    :type selenium:
+        :py:class:`~selenium.webdriver.remote.webdriver.WebDriver` object
+    """
+
+    _tracking_protection_shield_locator = (By.CSS_SELECTOR, '#tracking-protection-icon:-moz-lwtheme')
+
+    def __init__(self, selenium, *args, **kwargs):
+        self.selenium = selenium
+
+    @property
+    def tracking_shield(self):
+        """Returns the Tacking Protection enabled shield"""
+        time.sleep(30)
+        with self.selenium.context(self.selenium.CONTEXT_CHROME):
+            return self.selenium.find_element(
+                *self._tracking_protection_shield_locator)
+            #WebDriverWait(self.selenium, timeout=10).until(
+            #    lambda _: self.selenium.find_element(
+            #        *self._tracking_protection_shield_locator)
+            #)

--- a/foxpuppet/windows/browser/window.py
+++ b/foxpuppet/windows/browser/window.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.by import By
 
 from foxpuppet import expected
 from foxpuppet.windows import BaseWindow
+from foxpuppet.windows.browser.navbar import NavBar
 from foxpuppet.windows.browser.notifications import BaseNotification
 
 
@@ -22,6 +23,10 @@ class BrowserWindow(BaseWindow):
     _notification_locator = (
         By.CSS_SELECTOR, '#notification-popup popupnotification')
     _tab_browser_locator = (By.ID, 'tabbrowser-tabs')
+
+    @property
+    def navbar(self):
+        return (NavBar(self.selenium))
 
     @property
     def notification(self):

--- a/foxpuppet/windows/browser/window.py
+++ b/foxpuppet/windows/browser/window.py
@@ -26,7 +26,14 @@ class BrowserWindow(BaseWindow):
 
     @property
     def navbar(self):
-        return (NavBar(self.selenium))
+        """Provides access to the Navigation Bar.
+        :returns: :py:class:`~foxpuppet.windows.browser.navbar.NavBar`
+        :return type: object
+        """
+        window = BaseWindow(self.selenium, self.selenium.current_window_handle)
+        with self.selenium.context(self.selenium.CONTEXT_CHROME):
+            el = self.selenium.find_element(*self._nav_bar_locator)
+            return NavBar(window, el)
 
     @property
     def notification(self):

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,2 @@
-pytest==3.1.1
-pytest-selenium==1.10.0
+pytest==3.1.3
+pytest-selenium==1.11.0

--- a/tests/test_browser_model.py
+++ b/tests/test_browser_model.py
@@ -2,6 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import pytest
+from selenium.webdriver.support.wait import WebDriverWait
+
 
 def test_initial_browser_window(foxpuppet):
     """Tests initial state of browser windows"""
@@ -36,16 +39,16 @@ def test_close_window(foxpuppet):
 def test_switch_to(foxpuppet, selenium):
     """Test Switch to function"""
     foxpuppet.browser.open_window()
-
     # Switch to originally window opened by pytest
     foxpuppet.browser.switch_to()
     assert foxpuppet.browser.handle == selenium.current_window_handle
 
 
-def test_tracking_protection_sheild(foxpuppet, selenium):
-    browser = foxpuppet.browser.open_window(private=True)
-    browser.switch_to()
-    selenium.get('http://cnn.com')
-    assert browser.navbar.tracking_shield
-    selenium.get('http://support.mozilla.org')
-    assert foxpuppet.window_manager.windows[1].navbar.tracking_shield
+@pytest.mark.firefox_preferences({'privacy.trackingprotection.enabled': True})
+def test_tracking_protection_shield(foxpuppet, selenium):
+    """Tests if the tracking protection icon displays"""
+    browser = foxpuppet.browser
+    assert not browser.navbar.is_tracking_shield_displayed
+    selenium.get('https://www.washingtonpost.com/')
+    WebDriverWait(selenium, timeout=5).until(
+        lambda _: browser.navbar.is_tracking_shield_displayed)

--- a/tests/test_browser_model.py
+++ b/tests/test_browser_model.py
@@ -40,3 +40,12 @@ def test_switch_to(foxpuppet, selenium):
     # Switch to originally window opened by pytest
     foxpuppet.browser.switch_to()
     assert foxpuppet.browser.handle == selenium.current_window_handle
+
+
+def test_tracking_protection_sheild(foxpuppet, selenium):
+    browser = foxpuppet.browser.open_window(private=True)
+    browser.switch_to()
+    selenium.get('http://cnn.com')
+    assert browser.navbar.tracking_shield
+    selenium.get('http://support.mozilla.org')
+    assert foxpuppet.window_manager.windows[1].navbar.tracking_shield


### PR DESCRIPTION
@davehunt @whimboo @rbillings 

Fix for #72 

Found a simple solution that I missed before!
I also am not 100% on the api for this so I am open to suggestions. I don't know what you would do with the icon besides check if it was there.

Also, I am not keen on navigating to cnn.com but I don't think we could mock a webserver that triggers firefox's tracking protection stuff.