### PR TITLE
Bump geckodriver in Travis to latest, v0.19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ env:
   global:
     - DISPLAY=:99.0
 before_install:
-  - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz
+  - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
   - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver
   - export PATH=$HOME/geckodriver:$PATH
   - firefox --version


### PR DESCRIPTION
I confess I haven't-yet tested this locally.