### PR TITLE
Fix locator for add-on name in popup due to changes in bug 1431242

### DIFF
--- a/foxpuppet/windows/browser/notifications/addons.py
+++ b/foxpuppet/windows/browser/notifications/addons.py
@@ -21,7 +21,6 @@ class AddOnInstallBlocked(BaseNotification):
 class AddOnInstallConfirmation(BaseNotification):
     """Add-on install confirmation notification."""
 
-    _addon_name_locator = (By.CSS_SELECTOR, '#addon-webext-perm-header')
     _cancel_locator = (By.ID, 'addon-install-confirmation-cancel')
     _confirm_locator = (By.ID, 'addon-install-confirmation-accept')
 
@@ -34,8 +33,14 @@ class AddOnInstallConfirmation(BaseNotification):
 
         """
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
-            if self.window.firefox_version >= 55:
-                name = self.root.find_element(*self._addon_name_locator).text
+            if self.window.firefox_version >= 59:  # Bug 1431242
+                el = self.root.find_anonymous_element_by_attribute(
+                    'class', 'popup-notification-description')
+                return el.find_element(By.CSS_SELECTOR, 'b').text
+            elif self.window.firefox_version >= 55:
+                _addon_name_locator = (
+                    By.CSS_SELECTOR, '#addon-webext-perm-header')
+                name = self.root.find_element(*_addon_name_locator).text
                 return name.split()[1]
             else:
                 _addon_name_locator = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,8 @@ def browser(foxpuppet):
 def firefox_options(firefox_options):
     """Fixture for configuring Firefox."""
     firefox_options.log.level = 'trace'
+    # firefox_options.set_preference('devtools.chrome.enabled', True)
+    # firefox_options.set_preference('devtools.debugger.remote-enabled', True)
     return firefox_options
 
 


### PR DESCRIPTION
This should fix the tests that have been failing due to the changes in [bug 1431242](https://bugzilla.mozilla.org/show_bug.cgi?id=1431242).