### PR TITLE
Add and set PIPENV_IGNORE_VIRTUALENVS, to quell warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,9 @@ before_install:
   - export PATH=$HOME/geckodriver:$PATH
   - firefox --version
   - geckodriver --version
-install: pip install tox-travis
+install:
+  - export PIPENV_IGNORE_VIRTUALENVS=1
+  - pip install tox-travis
 before_script:
   - sh -e /etc/init.d/xvfb start
   - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ env:
     - DISPLAY=:99.0
     - GECKODRIVER_VERSION=0.21.0
     - MOZ_HEADLESS=1
+    - export PIPENV_IGNORE_VIRTUALENVS=1
 before_install:
   - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz
   - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver
@@ -108,7 +109,6 @@ before_install:
   - firefox --version
   - geckodriver --version
 install:
-  - export PIPENV_IGNORE_VIRTUALENVS=1
   - pip install tox-travis
 before_script:
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,6 @@ env:
     - DISPLAY=:99.0
     - GECKODRIVER_VERSION=0.21.0
     - MOZ_HEADLESS=1
-    - PIPENV_IGNORE_VIRTUALENVS=1
 before_install:
   - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz
   - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ env:
     - DISPLAY=:99.0
     - GECKODRIVER_VERSION=0.21.0
     - MOZ_HEADLESS=1
-    - export PIPENV_IGNORE_VIRTUALENVS=1
+    - PIPENV_IGNORE_VIRTUALENVS=1
 before_install:
   - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz
   - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,8 +108,7 @@ before_install:
   - export PATH=$HOME/geckodriver:$PATH
   - firefox --version
   - geckodriver --version
-install:
-  - pip install tox-travis
+install: pip install tox-travis
 before_script:
   - sh -e /etc/init.d/xvfb start
   - sleep 10

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,13 @@ envlist = py{27,36}, flake8, docs
 recreate = True
 passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH \
           PIPENV_IGNORE_VIRTUALENVS
+
+setenv = PIPENV_IGNORE_VIRTUALENS
 deps = -rpipenv.txt
 commands =
     pipenv install --dev --skip-lock
     pipenv run pytest --driver Firefox --cov --html results/{envname}.html {posargs}
-    coveralls
+    pipenv run coveralls
 
 [testenv:docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ recreate = True
 passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH \
           PIPENV_IGNORE_VIRTUALENVS
 
-setenv = PIPENV_IGNORE_VIRTUALENS
+setenv = PIPENV_IGNORE_VIRTUALENS=1
 deps = -rpipenv.txt
 commands =
     pipenv install --dev --skip-lock

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist = py{27,36}, flake8, docs
 
 [testenv]
 recreate = True
-passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH \
+          PIPENV_IGNORE_VIRTUALENVS=1
 deps = -rpipenv.txt
 commands =
     pipenv install --dev --skip-lock

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@ envlist = py{27,36}, flake8, docs
 recreate = True
 passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
-setenv = PIPENV_IGNORE_VIRTUALENS=1
+setenv = PIPENV_IGNORE_VIRTUALENVS=1
 deps = -rpipenv.txt
 commands =
     pipenv install --dev --skip-lock
     pipenv run pytest --driver Firefox --cov --html results/{envname}.html {posargs}
-    pipenv run coveralls
+    - pipenv run coveralls
 
 [testenv:docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ envlist = py{27,36}, flake8, docs
 
 [testenv]
 recreate = True
-passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH \
-          PIPENV_IGNORE_VIRTUALENVS
+passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 setenv = PIPENV_IGNORE_VIRTUALENS=1
 deps = -rpipenv.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{27,36}, flake8, docs
 [testenv]
 recreate = True
 passenv = DISPLAY MOZ_HEADLESS TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH \
-          PIPENV_IGNORE_VIRTUALENVS=1
+          PIPENV_IGNORE_VIRTUALENVS
 deps = -rpipenv.txt
 commands =
     pipenv install --dev --skip-lock


### PR DESCRIPTION
Quells this warning in Travis CI builds:

```
Courtesy Notice: Pipenv found itself running within a virtual environment, so it will automatically use that environment, instead of creating its own for any project. You can set PIPENV_IGNORE_VIRTUALENVS=1 to force pipenv to ignore that environment and create its own instead.
```