### PR TITLE
Add support for new notification selectors

### DIFF
--- a/foxpuppet/windows/browser/notifications/addons.py
+++ b/foxpuppet/windows/browser/notifications/addons.py
@@ -14,7 +14,7 @@ class AddOnInstallBlocked(BaseNotification):
     def allow(self):
         """Allow the add-on to be installed."""
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
-            self.root.find_anonymous_element_by_attribute("anonid", "button").click()
+            self.find_primary_button().click()
 
 
 class AddOnInstallConfirmation(BaseNotification):
@@ -29,22 +29,18 @@ class AddOnInstallConfirmation(BaseNotification):
 
         """
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
-            el = self.root.find_anonymous_element_by_attribute(
-                "class", "popup-notification-description"
-            )
+            el = self.find_description()
             return el.find_element(By.CSS_SELECTOR, "b").text
 
     def cancel(self):
         """Cancel add-on install."""
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
-            self.root.find_anonymous_element_by_attribute(
-                "anonid", "secondarybutton"
-            ).click()
+            self.find_secondary_button().click()
 
     def install(self):
         """Confirm add-on install."""
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
-            self.root.find_anonymous_element_by_attribute("anonid", "button").click()
+            self.find_primary_button().click()
 
 
 class AddOnInstallComplete(BaseNotification):
@@ -54,9 +50,7 @@ class AddOnInstallComplete(BaseNotification):
         """Close the notification."""
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
             if self.window.firefox_version > 63:
-                self.root.find_anonymous_element_by_attribute(
-                    "anonid", "button"
-                ).click()
+                self.find_primary_button().click()
                 self.window.wait_for_notification(None)
             else:
                 BaseNotification.close(self)

--- a/foxpuppet/windows/browser/notifications/base.py
+++ b/foxpuppet/windows/browser/notifications/base.py
@@ -61,6 +61,7 @@ class BaseNotification(Region):
             return self.root.get_attribute("origin")
 
     def find_primary_button(self):
+        """Retrieve the primary button"""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-primary-button")
@@ -68,6 +69,7 @@ class BaseNotification(Region):
             "anonid", "button")
 
     def find_secondary_button(self):
+        """Retrieve the secondary button"""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-secondary-button")
@@ -75,6 +77,7 @@ class BaseNotification(Region):
             "anonid", "secondarybutton")
 
     def find_description(self):
+        """Retrieve the notification description"""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-description")
@@ -82,6 +85,7 @@ class BaseNotification(Region):
             "class", "popup-notification-description")
 
     def find_close_button(self):
+        """Retrieve the close button"""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-closebutton")

--- a/foxpuppet/windows/browser/notifications/base.py
+++ b/foxpuppet/windows/browser/notifications/base.py
@@ -61,7 +61,7 @@ class BaseNotification(Region):
             return self.root.get_attribute("origin")
 
     def find_primary_button(self):
-        """Retrieve the primary button"""
+        """Retrieve the primary button."""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-primary-button")
@@ -69,7 +69,7 @@ class BaseNotification(Region):
             "anonid", "button")
 
     def find_secondary_button(self):
-        """Retrieve the secondary button"""
+        """Retrieve the secondary button."""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-secondary-button")
@@ -77,7 +77,7 @@ class BaseNotification(Region):
             "anonid", "secondarybutton")
 
     def find_description(self):
-        """Retrieve the notification description"""
+        """Retrieve the notification description."""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-description")
@@ -85,7 +85,7 @@ class BaseNotification(Region):
             "class", "popup-notification-description")
 
     def find_close_button(self):
-        """Retrieve the close button"""
+        """Retrieve the close button."""
         if self.window.firefox_version >= 67:
             return self.root.find_element(
                 By.CLASS_NAME, "popup-notification-closebutton")

--- a/foxpuppet/windows/browser/notifications/base.py
+++ b/foxpuppet/windows/browser/notifications/base.py
@@ -5,6 +5,8 @@
 
 from abc import ABCMeta
 
+from selenium.webdriver.common.by import By
+
 from foxpuppet.region import Region
 
 
@@ -58,10 +60,36 @@ class BaseNotification(Region):
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
             return self.root.get_attribute("origin")
 
+    def find_primary_button(self):
+        if self.window.firefox_version >= 67:
+            return self.root.find_element(
+                By.CLASS_NAME, "popup-notification-primary-button")
+        return self.root.find_anonymous_element_by_attribute(
+            "anonid", "button")
+
+    def find_secondary_button(self):
+        if self.window.firefox_version >= 67:
+            return self.root.find_element(
+                By.CLASS_NAME, "popup-notification-secondary-button")
+        return self.root.find_anonymous_element_by_attribute(
+            "anonid", "secondarybutton")
+
+    def find_description(self):
+        if self.window.firefox_version >= 67:
+            return self.root.find_element(
+                By.CLASS_NAME, "popup-notification-description")
+        return self.root.find_anonymous_element_by_attribute(
+            "class", "popup-notification-description")
+
+    def find_close_button(self):
+        if self.window.firefox_version >= 67:
+            return self.root.find_element(
+                By.CLASS_NAME, "popup-notification-closebutton")
+        return self.root.find_anonymous_element_by_attribute(
+            "anonid", "closebutton")
+
     def close(self):
         """Close the notification."""
         with self.selenium.context(self.selenium.CONTEXT_CHROME):
-            self.root.find_anonymous_element_by_attribute(
-                "anonid", "closebutton"
-            ).click()
+            self.find_close_button().click()
         self.window.wait_for_notification(None)


### PR DESCRIPTION
The notifications have been refactored in FF (see: https://phabricator.services.mozilla.com/D17699) and there is no anonymous element anymore. Instead, we can use `find_element` directly and use a `by.CLASS_NAME` selector.

This PR updates the notification code to be compatible with Nightly 67.0a1 and above, while keeping backward compatibility for older versions.

This patch has been tested locally on https://github.com/mozilla/addons-frontend.