### PR TITLE
chore(project): Enforce code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BLACK_CHECK = black -l 90 --check --diff .
 BLACK_FIX = black -l 90 .
-FOXPUPPET_TESTS = pytest -vvv --driver Firefox --cov --html results/report.html
+MINIMUM_COVERAGE = 95.41
+FOXPUPPET_TESTS = pytest -vvv --driver Firefox --cov --cov-fail-under=$(MINIMUM_COVERAGE) --html results/report.html
 
 check: install_poetry lint test
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BLACK_CHECK = black -l 90 --check --diff .
 BLACK_FIX = black -l 90 .
-MINIMUM_COVERAGE = 95.41
+MINIMUM_COVERAGE = 95
 FOXPUPPET_TESTS = pytest -vvv --driver Firefox --cov --cov-fail-under=$(MINIMUM_COVERAGE) --html results/report.html
 
 check: install_poetry lint test


### PR DESCRIPTION
Because

* We need to ensure that as the project grows, we push for increased coverage by adding a check to the CI runs to not allow a decrease in the current coverage.

This commit

* Enforces a 95.41% code test coverage

Fixes #323 
