### PR TITLE
Github deployment workflow for PyPI

### DIFF
--- a/.github/workflows/foxpuppet_deploy.yml
+++ b/.github/workflows/foxpuppet_deploy.yml
@@ -1,9 +1,9 @@
 name: Publish to PyPI
 
 on:
-  pull_request:
-    branches:
-      - main
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 env:
   PYTHON_VERSION: '3.12'

--- a/.github/workflows/foxpuppet_deploy.yml
+++ b/.github/workflows/foxpuppet_deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Setup Firefox
         id: setup-firefox
-        uses: ./.github/actions/setup_firefox/  
+        uses: ./.github/actions/setup_firefox/
         with:
           firefox-version: latest
 
@@ -45,16 +45,8 @@ jobs:
           python -m venv wheel-env
           source wheel-env/bin/activate
           pip install dist/*.whl
-          pip install pytest pytest-selenium pytest-cov pytest-html
           mkdir -p results
-          export PYTHONUNBUFFERED=1
-          export MOZ_HEADLESS=1
-          export GECKODRIVER_LOG="$(pwd)/results/geckodriver.log"
-          pytest -vvv \
-            --driver Firefox \
-            --capture=no \
-            --cov --cov-fail-under=95 \
-            --html results/report.html 2>&1 | tee results/pytest.log
+          make test
           deactivate
 
       - name: Install and Test the Tarball
@@ -64,14 +56,7 @@ jobs:
           pip install dist/*.tar.gz
           pip install pytest pytest-selenium pytest-cov pytest-html
           mkdir -p results
-          export PYTHONUNBUFFERED=1
-          export MOZ_HEADLESS=1
-          export GECKODRIVER_LOG="$(pwd)/results/geckodriver.log"
-          pytest -vvv \
-            --driver Firefox \
-            --capture=no \
-            --cov --cov-fail-under=95 \
-            --html results/report.html 2>&1 | tee results/pytest.log
+          make test
           deactivate
 
       - name: Publish to PyPI

--- a/.github/workflows/foxpuppet_deploy.yml
+++ b/.github/workflows/foxpuppet_deploy.yml
@@ -49,6 +49,16 @@ jobs:
           make test
           deactivate
 
+      - name: Upload Wheel Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-test-results
+          path: |
+            results/report.html
+            results/geckodriver.log
+          retention-days: 14
+
       - name: Install and Test the Tarball
         run: |
           python -m venv tarball-env
@@ -58,6 +68,16 @@ jobs:
           mkdir -p results
           make test
           deactivate
+
+      - name: Upload Tarball Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarball-test-results
+          path: |
+            results/report.html
+            results/geckodriver.log
+          retention-days: 14
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/foxpuppet_deploy.yml
+++ b/.github/workflows/foxpuppet_deploy.yml
@@ -1,0 +1,105 @@
+name: Publish to PyPI
+
+
+on:
+    pull_request:
+      # Sequence of patterns matched against refs/heads
+      branches:
+        - main
+# on:
+#   release:
+#     types:
+#       - created
+
+env:
+  PYTHON_VERSION: '3.12'
+
+jobs:
+  test-and-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
+          export PATH="$HOME/.local/bin:$PATH"
+
+      - name: Setup Firefox
+        id: setup-firefox
+        uses: ./.github/actions/setup_firefox/
+        with:
+          firefox-version: ${{ matrix.firefox }}
+
+      - run: |
+          echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
+
+      - name: Echo Geckodriver Path and Version
+        run: |
+          echo "Geckodriver is installed at: $(which geckodriver)"
+          geckodriver --version
+
+      - name: Build the Package
+        run: poetry build
+
+      -name: Install and Test the Wheel
+        run: |
+          python -m venv wheel-env
+          source wheel-env/bin/activate
+          pip install dist/*.whl
+          pip install pytest pytest-selenium pytest-cov pytest-html
+          mkdir -p results
+          export PYTHONUNBUFFERED=1
+          export MOZ_HEADLESS=1
+          export GECKODRIVER_LOG="$(pwd)/results/geckodriver.log"
+          pytest -vvv \
+            --driver Firefox \
+            --capture=no \
+            --cov --cov-fail-under=95 \
+            --html results/report.html 2>&1 | tee results/pytest.log
+          deactivate
+
+      - name: Install and Test the Tarball
+        run: |
+          python -m venv tarball-env
+          source tarball-env/bin/activate
+          pip install dist/*.tar.gz
+          pip install pytest pytest-selenium pytest-cov pytest-html
+          mkdir -p results
+          export PYTHONUNBUFFERED=1
+          export MOZ_HEADLESS=1
+          export GECKODRIVER_LOG="$(pwd)/results/geckodriver.log"
+          pytest -vvv \
+            --driver Firefox \
+            --capture=no \
+            --cov --cov-fail-under=95 \
+            --html results/report.html 2>&1 | tee results/pytest.log
+          deactivate
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  create-release:
+    name: Create GitHub Release
+    needs: test-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/*.whl dist/*.tar.gz \
+            --title "Release ${GITHUB_REF_NAME}" \
+            --notes "Automated release of version ${GITHUB_REF_NAME}"

--- a/.github/workflows/foxpuppet_deploy.yml
+++ b/.github/workflows/foxpuppet_deploy.yml
@@ -1,11 +1,10 @@
 name: Publish to PyPI
 
-
 on:
-    pull_request:
-      # Sequence of patterns matched against refs/heads
-      branches:
-        - main
+  pull_request:
+    branches:
+      - main
+
 # on:
 #   release:
 #     types:

--- a/.github/workflows/foxpuppet_deploy.yml
+++ b/.github/workflows/foxpuppet_deploy.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
 
-# on:
-#   release:
-#     types:
-#       - created
-
 env:
   PYTHON_VERSION: '3.12'
 
@@ -33,22 +28,19 @@ jobs:
 
       - name: Setup Firefox
         id: setup-firefox
-        uses: ./.github/actions/setup_firefox/
+        uses: ./.github/actions/setup_firefox/  
         with:
-          firefox-version: ${{ matrix.firefox }}
+          firefox-version: latest
 
-      - run: |
-          echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
-
-      - name: Echo Geckodriver Path and Version
+      - name: Verify Firefox Installation
         run: |
-          echo "Geckodriver is installed at: $(which geckodriver)"
-          geckodriver --version
+          echo Installed Firefox version:
+          firefox --version
 
       - name: Build the Package
         run: poetry build
 
-      -name: Install and Test the Wheel
+      - name: Install and Test the Wheel
         run: |
           python -m venv wheel-env
           source wheel-env/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-export PYTHONUNBUFFERED = 1
 export MOZ_HEADLESS = 1
 export GECKODRIVER_LOG = $(shell pwd)/results/geckodriver.log
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+export PYTHONUNBUFFERED = 1
+export MOZ_HEADLESS = 1
+export GECKODRIVER_LOG = $(shell pwd)/results/geckodriver.log
+
 BLACK_CHECK = black -l 90 --check --diff .
 BLACK_FIX = black -l 90 .
 MINIMUM_COVERAGE = 95


### PR DESCRIPTION
Because

* We need to start deploying FoxPuppet for external consumption by building and deploying to PyPI

This commit

* This PR adds a file for building, testing the build, and deploying the build to PyPI

Fixes #333 
