### PR TITLE
type(fix): Ensure GitHub Action runs the latest versions of Firefox

### DIFF
--- a/.github/workflows/foxpuppet_deploy.yml
+++ b/.github/workflows/foxpuppet_deploy.yml
@@ -26,15 +26,21 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
           export PATH="$HOME/.local/bin:$PATH"
 
+      - name: Remove Firefox
+        run: |
+          sudo rm -rf /usr/bin/firefox
+          echo "Firefox has been removed."
+
       - name: Setup Firefox
         id: setup-firefox
-        uses: ./.github/actions/setup_firefox/
+        uses: browser-actions/setup-firefox@v1    #./.github/actions/setup_firefox/
         with:
           firefox-version: latest
 
       - name: Verify Firefox Installation
         run: |
           echo Installed Firefox version:
+          which firefox
           firefox --version
 
       - name: Build the Package

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -31,13 +31,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Remove Firefox
+        run: |
+          sudo rm -rf /usr/bin/firefox
+          echo "Firefox has been removed."
       - name: Setup firefox
         id: setup-firefox
-        uses: ./.github/actions/setup_firefox/   # browser-actions/setup-firefox@v1
+        uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: ${{ matrix.firefox }}
       - run: |
           echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
+      - name: Verify Firefox Installation
+        run: |
+          echo Installed Firefox version:
+          which firefox
+          firefox --version
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/foxpuppet/windows/browser/bookmarks/bookmark.py
+++ b/foxpuppet/windows/browser/bookmarks/bookmark.py
@@ -4,7 +4,8 @@
 """Contains classes for handling Firefox bookmarks."""
 
 from selenium.webdriver.common.by import By
-from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.common.keys import Keys
 from foxpuppet.windows.browser.navbar import NavBar
@@ -75,6 +76,9 @@ class Bookmark(NavBar):
                     self.actions.context_click(
                         self.selenium.find_element(*BookmarkLocators.NAVIGATOR_TOOLBOX)
                     ).perform()
+                    WebDriverWait(self.selenium, 10).until(
+                        EC.presence_of_element_located(BookmarkLocators.MENU_BAR)
+                    )
                     self.selenium.find_element(*BookmarkLocators.MENU_BAR).click()
                     self.selenium.find_element(
                         *BookmarkLocators.MAIN_MENU_BOOKMARK
@@ -197,7 +201,7 @@ class BookmarkLocators:
     MANAGE_BOOKMARKS = (By.ID, "bookmarksShowAll")
     MENU_BAR = (By.ID, "toggle_toolbar-menubar")
     NAME_FIELD = (By.ID, "editBMPanel_namePicker")
-    NAVIGATOR_TOOLBOX = (By.ID, "navigator-toolbox")
+    NAVIGATOR_TOOLBOX = (By.ID, "TabsToolbar")
     OTHER_BOOKMARKS = (By.ID, "OtherBookmarks")
     OTHER_BOOKMARKS_STAR = (By.ID, "editBMPanel_unfiledRootItem")
     PANEL_BOOKMARK_MENU = (By.ID, "appMenu-bookmarks-button")


### PR DESCRIPTION
Because

* FoxPuppet needs to be updated to reflect new updates to the Firefox browser. This won't be possible if tests are not running again the latest versions of Firefox.
* The is_private property defined on the BrowserWindow class is outdated.

This commit

* Ensure FoxPuppet tests are running against the latest Firefox versions.
* Updates the is_private method to use Private Window ESM module. This is done using dynamic imports.

Fixes #344, #346
