### PR TITLE
chore(project): Enable chrome scope access via selenium options.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ def browser(foxpuppet: FoxPuppet) -> BrowserWindow:
 def firefox_options(firefox_options: FirefoxOptions) -> FirefoxOptions:
     """Fixture for configuring Firefox."""
     firefox_options.log.level = "trace"  # type: ignore
+    firefox_options.set_preference("remote.system-access-check.enabled", False)
     # firefox_options.set_preference('devtools.chrome.enabled', True)
     # firefox_options.set_preference('devtools.debugger.remote-enabled', True)
     return firefox_options


### PR DESCRIPTION
Because

* chrome scope access is being put behind a flag in an upcoming selenium release

This commit

* Enables chrome scope access via selenium options.

Fixes #354 
